### PR TITLE
Fix kick error

### DIFF
--- a/src/main/java/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
+++ b/src/main/java/vg/civcraft/mc/civchat2/listeners/CivChat2Listener.java
@@ -82,7 +82,7 @@ public class CivChat2Listener implements Listener {
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerKick(PlayerKickEvent playerKickEvent) {
-		playerKickEvent.setLeaveMessage(null);
+		playerKickEvent.setLeaveMessage("You have been kicked");
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
In Paper 1.16.5, player leave messages cannot be null